### PR TITLE
Fix Dialog destroy handler

### DIFF
--- a/src/components/Dialog/Dialog.svelte
+++ b/src/components/Dialog/Dialog.svelte
@@ -128,7 +128,7 @@
   function close() {
     resolve(hasInput ? null : false)
     active = false
-    dispatch('destroyed')
+    dispatch('destroy')
   }
 
   async function confirm() {

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -10,7 +10,7 @@ function createDialog(props) {
   });
 
   dialog.$on('destroy', () => {
-    dialog.$destroy
+    dialog.$destroy()
   })
 
   return dialog.promise


### PR DESCRIPTION
**Issue 1**: Original code would fire the `destroyed` event, whilst the event listener was listening for `destroy`.  
**Solution**: Change fired event to `destroy`

**Issue 2**: Svelte `.$destroy` function was referenced but not called  
**Solution**: Execute the function