### PR TITLE
Allow Input component to propagate events. 

### DIFF
--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -1,6 +1,8 @@
 <script>
   import { createEventDispatcher, onMount, getContext, tick } from 'svelte'
-  import { omit } from '../utils'
+  import { omit, getEventsAction } from '../utils'
+  import { current_component } from 'svelte/internal'
+	
   import Icon from './Icon.svelte'
 
   /** Binding value
@@ -125,6 +127,8 @@
   }
   const onFocus = () => (isFocused = true)
   const onBlur = () => (isFocused = false)
+
+  const events = getEventsAction(current_component);
 </script>
 
 <style>
@@ -138,6 +142,7 @@
 
   {#if type !== 'textarea'}
     <input
+      use:events
       {...props}
       type={newType}
       {value}
@@ -150,6 +155,7 @@
       {disabled} />
   {:else}
     <textarea
+      use:events
       {...props}
       {value}
       class="textarea {statusType}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import * as transitions from 'svelte/transition'
+import { bubble, listen } from "svelte/internal";
 
 export function chooseAnimation(animation) {
   return typeof animation === 'function' ? animation : transitions[animation]
@@ -32,4 +33,19 @@ export function typeToIcon(type) {
     default:
       return null
   }
+}
+
+export function getEventsAction(component) {
+  return node => {
+    const events = Object.keys(component.$$.callbacks);
+    const listeners = [];
+    events.forEach(event =>
+      listeners.push(listen(node, event, e => bubble(component, e)))
+    );
+    return {
+      destroy: () => {
+        listeners.forEach(listener => listener());
+      }
+    };
+  };
 }


### PR DESCRIPTION
### Allow **Input** component to propagate events: 
#### Usage:
```
<script>
        let isFocused = false;
        const onInput =(e)=>value=e.target.value;
	const onFocus =()=>isFocused=true;
	const onBlur =()=>isFocused=false;
</script>

<Input on:input={onInput} on:focus={onFocus} on:blur={onBlur} {value}/>
```

Demo : [This REPL](https://svelte.dev/repl/dbeabf42636545b3a8dc6ebe84c2d98c?version=3.17.3)