### PR TITLE
fix(doc): fix Codesandbox examples

### DIFF
--- a/docs/src/components/CodepenButton.svelte
+++ b/docs/src/components/CodepenButton.svelte
@@ -76,7 +76,7 @@ export default app;`,
             'sirv-cli': '^0.3.1',
           },
           dependencies: {
-            svelte: 'latest',
+            svelte: '^3.0.0',
             svelma: 'latest',
             '@fortawesome/fontawesome-free': 'latest',
             bulma: 'latest',


### PR DESCRIPTION
For some reason svelte does not work with "latest" in CodeSandbox. Using the latest v3 seems to work, however.

Fixes #84