### PR TITLE
Fix "resolve not found" error in Dialogs

### DIFF
--- a/src/components/Dialog/Dialog.svelte
+++ b/src/components/Dialog/Dialog.svelte
@@ -84,7 +84,7 @@
 
   // export let showClose = true
   let resolve
-  // export let promise = new Promise((fulfil) => (resolve = fulfil))
+  export let promise = new Promise((fulfil) => (resolve = fulfil))
   
   // TODO: programmatic subcomponents
   // export let subComponent = null


### PR DESCRIPTION
Fixes #109.

Add back promise resolve where an (accidental) dev commit commented out an additional line in `Dialog.svelte`